### PR TITLE
update for g:include(issue 10991)

### DIFF
--- a/grails-plugin-gsp/src/main/groovy/org/grails/plugins/web/taglib/UrlMappingTagLib.groovy
+++ b/grails-plugin-gsp/src/main/groovy/org/grails/plugins/web/taglib/UrlMappingTagLib.groovy
@@ -3,6 +3,7 @@ package org.grails.plugins.web.taglib
 import grails.artefact.TagLibrary
 import grails.gsp.TagLib
 import grails.util.TypeConvertingMap
+import grails.web.mapping.LinkGenerator
 import grails.web.mapping.UrlMapping
 import groovy.transform.CompileStatic
 import org.grails.encoder.CodecLookup
@@ -12,6 +13,7 @@ import org.grails.taglib.encoder.OutputContextLookupHelper
 import org.grails.web.mapping.ForwardUrlMappingInfo
 import org.grails.web.mapping.UrlMappingUtils
 import org.grails.web.util.GrailsApplicationAttributes
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.web.servlet.support.RequestContextUtils
 
 /**
@@ -25,6 +27,9 @@ import org.springframework.web.servlet.support.RequestContextUtils
 class UrlMappingTagLib implements TagLibrary{
 
     CodecLookup codecLookup
+
+    @Autowired
+    LinkGenerator linkGenerator
 
     /**
      * Includes another controller/action within the current response.<br/>
@@ -60,7 +65,7 @@ class UrlMappingTagLib implements TagLibrary{
             if (attrs.plugin != null) {
                 mapping.pluginName = attrs.plugin as String
             }
-            out << UrlMappingUtils.includeForUrlMappingInfo(request, response, mapping, (Map)(attrs.model ?: [:]))?.content
+            out << UrlMappingUtils.includeForUrlMappingInfo(request, response, mapping, (Map)(attrs.model ?: [:]), linkGenerator)?.content
         }
     }
 


### PR DESCRIPTION
In order to apply the fix for https://github.com/grails/grails-core/issues/10991, grails-core (branch issue-10991) needs to be merged https://github.com/grails/grails-core/pull/11003. Once core has been updated with the necessary changes grails-gsp will require updated grails as the grails-gsp version is currently only 3.2.10.

If grails-core has not been rebuild and the version updated in grails-gsp it will complain that it cant find the proper method signature to call in grails-core