### PR TITLE
Ignore commas in taglib attributes. Fixes #25

### DIFF
--- a/grails-gsp/src/main/groovy/org/grails/gsp/GroovyPage.java
+++ b/grails-gsp/src/main/groovy/org/grails/gsp/GroovyPage.java
@@ -332,6 +332,15 @@ public abstract class GroovyPage extends Script {
     public final void invokeTag(String tagName, String tagNamespace, int lineNumber, Map attrs, int bodyClosureIndex) {
         Closure body = getBodyClosure(bodyClosureIndex);
 
+        // See https://github.com/grails/grails-gsp/issues/25
+        Map cleanedAttrs = new LinkedHashMap();
+        for (Object o : attrs.entrySet()) {
+            Map.Entry<String, ?> entry = (Map.Entry) o;
+            String newKey = entry.getKey().replaceAll(",", "").trim();
+            cleanedAttrs.put(newKey, entry.getValue());
+        }
+        attrs = cleanedAttrs;
+
         // TODO custom namespace stuff needs to be generalized and pluggable
         if (tagNamespace.equals(TEMPLATE_NAMESPACE) || tagNamespace.equals(LINK_NAMESPACE)) {
             final String tmpTagName = tagName;

--- a/grails-plugin-gsp/src/test/groovy/org/grails/web/taglib/RemoveCommaFromArgumentsTagLibTests.groovy
+++ b/grails-plugin-gsp/src/test/groovy/org/grails/web/taglib/RemoveCommaFromArgumentsTagLibTests.groovy
@@ -1,0 +1,32 @@
+package org.grails.web.taglib
+
+import grails.artefact.Artefact
+import grails.test.mixin.TestFor
+import spock.lang.Specification
+
+@TestFor(ConcatTagLib)
+class RemoveCommaFromArgumentsTagLibTests extends Specification {
+
+    void 'test invoke tag lib with multiple params with commas'() {
+        expect:
+        applyTemplate('<g:concatAllAttrsKeys one="1" two="2", three="3" four="4" five="5" />') == 'onetwothreefourfive'
+
+        and:
+        applyTemplate('<g:concatAllAttrsValues one="1" two="2", three="3" four="4" five="5" />') == '12345'
+    }
+}
+
+@Artefact('TagLib')
+class ConcatTagLib {
+    Closure concatAllAttrsKeys = { attrs, body ->
+        attrs.each { attr ->
+            out << attr.key
+        }
+    }
+
+    Closure concatAllAttrsValues = { attrs, body ->
+        attrs.each { attr ->
+            out << attr.value
+        }
+    }
+}


### PR DESCRIPTION
Fix for grails/grails-views#714. I'm not sure if this is the best/right approach but as adding a comma while in between parameters in a taglib can be common I'm protecting the code to that specific case.