### PR TITLE
link to pageScope doc

### DIFF
--- a/src/main/docs/guide/taglibs/taglibVariablesAndScopes.adoc
+++ b/src/main/docs/guide/taglibs/taglibVariablesAndScopes.adoc
@@ -5,7 +5,7 @@ Within the scope of a tag library there are a number of pre-defined variables in
 * `flash` - The link:{controllersRef}/flash.html[flash] object
 * `grailsApplication` - The http://docs.grails.org/latest/api/grails/core/GrailsApplication.html[GrailsApplication] instance
 * `out` - The response writer for writing to the output stream
-* `pageScope` - A reference to the <<ref-tag-libraries-pageScope,pageScope>> object used for GSP rendering (i.e. the binding)
+* `pageScope` - A reference to the https://gsp.grails.org/latest/ref/Tag%20Libraries/pageScope.html[pageScope] object used for GSP rendering (i.e. the binding)
 * `params` - The link:{controllersRef}/params.html[params] object for retrieving request parameters
 * `pluginContextPath` - The context path to the plugin that contains the tag library
 * `request` - The http://docs.oracle.com/javaee/1.4/api/javax/servlet/http/HttpServletRequest.html[HttpServletRequest] instance


### PR DESCRIPTION
Noticed that the link to the pageScope in the Variables and Scopes section wasn't live.