### PR TITLE
Removes default empty string for namespace #44

### DIFF
--- a/grails-plugin-gsp/src/main/groovy/org/grails/plugins/web/taglib/UrlMappingTagLib.groovy
+++ b/grails-plugin-gsp/src/main/groovy/org/grails/plugins/web/taglib/UrlMappingTagLib.groovy
@@ -257,7 +257,7 @@ class UrlMappingTagLib implements TagLibrary{
 
         def property = attrs.remove("property")
         def action = attrs.action ? attrs.remove("action") : (actionName ?: "list")
-        def namespace = attrs.namespace ? attrs.remove("namespace") : ""
+        def namespace = attrs.remove("namespace")
 
         def defaultOrder = attrs.remove("defaultOrder")
         if (defaultOrder != "desc") defaultOrder = "asc"


### PR DESCRIPTION
Hej! 

This is the pull request for issue #44.

I've added several tests including custom mappings with custom namespaces. There are also 2 relevant test cases in ReverseUrlMappingTests named `testSortableColumnWithNamedUrlMapping` and `testSortableColumnWithNamespaceAttribute` which still ensures that every thing runs well when setting the namespace or mapping as property.

I made the pull request against 3.3.x as we are not yet able to migrate to Grails 4 in the near future. If you want I can prepare a pull request for 4.x too but I think its much easier to cherry pick the changes after being merged to 3.3.x.

