### PR TITLE
Added check to enforce the name attribute of the checkBox tag. Fixes #46

### DIFF
--- a/grails-plugin-gsp/src/main/groovy/org/grails/plugins/web/taglib/FormTagLib.groovy
+++ b/grails-plugin-gsp/src/main/groovy/org/grails/plugins/web/taglib/FormTagLib.groovy
@@ -185,6 +185,11 @@ class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrar
     Closure checkBox = { attrs ->
         def value = attrs.remove('value')
         def name = attrs.remove('name')
+
+        if(!name){
+            throwTagError("Tag [checkBox] missing required attribute [name]")
+        }
+
         booleanToAttribute(attrs, 'disabled')
         booleanToAttribute(attrs, 'readonly')
 


### PR DESCRIPTION
Added proper error handling to the checkBox tag in FormTagLib.
Previously, if the name attribute was not provided, the tag
assumed the name attribute was non-null and errored on an
indexOf call later in the tag. This commit adds a null check
to the name attribute and throws an appropriate error if
name is null