### PR TITLE
Escape the checkBox tag's name property to prevent XSS attacks

### DIFF
--- a/grails-plugin-gsp/src/main/groovy/org/grails/plugins/web/taglib/FormTagLib.groovy
+++ b/grails-plugin-gsp/src/main/groovy/org/grails/plugins/web/taglib/FormTagLib.groovy
@@ -41,7 +41,6 @@ import org.springframework.core.convert.ConversionService
 import org.springframework.http.HttpMethod
 import org.springframework.web.servlet.support.RequestContextUtils as RCU
 import org.springframework.web.servlet.support.RequestDataValueProcessor
-
 /**
  * Tags for working with form controls.
  *
@@ -202,7 +201,10 @@ class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrar
 
         if (value == null) value = false
         def hiddenValue = ""
-
+        
+        //escape the name string to avoid potential XSS attacks
+        name =  name.encodeAsHTML()
+        
         def unprocessed = value
         value = processFormFieldValueIfNecessary(name, value,"checkbox")
         hiddenValue = processFormFieldValueIfNecessary("_${name}", hiddenValue, "hidden")


### PR DESCRIPTION
The name attribute in the checkBox tag in FormTagLib previously
was inserted directly into the resulting input tag's list of properties,
allowing an attacker to add undesired html attributes to the input
tag, including js listener attributes like onClick. This commit simply
escapes the name attribute using the builtin encodeAsHTML method.