### PR TITLE
Change paginate taglib to prefer override on taglib offset param 

### DIFF
--- a/grails-plugin-gsp/src/main/groovy/org/grails/plugins/web/taglib/UrlMappingTagLib.groovy
+++ b/grails-plugin-gsp/src/main/groovy/org/grails/plugins/web/taglib/UrlMappingTagLib.groovy
@@ -99,11 +99,9 @@ class UrlMappingTagLib implements TagLibrary{
         def locale = RequestContextUtils.getLocale(request)
 
         def total = attrs.int('total') ?: 0
-        def offset = params.int('offset') ?: 0
+        def offset = attrs.int('offset') ?: params.int('offset') ?: 0
         def max = params.int('max')
         def maxsteps = (attrs.int('maxsteps') ?: 10)
-
-        if (!offset) offset = (attrs.int('offset') ?: 0)
         if (!max) max = (attrs.int('max') ?: 10)
 
         Map linkParams = [:]


### PR DESCRIPTION
Resolves issue 11471 where specifying an offset attribute on the taglib does not take precedence from the param as it should. Most others like max take params as precedence which makes sense. But if an explicit offset is set. it should be using variables.

Fixes grails/grails-core#11471
