### PR TITLE
enable recognition of "encodeAs" parameter for fieldErrors

### DIFF
--- a/grails-plugin-gsp/src/main/groovy/org/grails/plugins/web/taglib/ValidationTagLib.groovy
+++ b/grails-plugin-gsp/src/main/groovy/org/grails/plugins/web/taglib/ValidationTagLib.groovy
@@ -62,10 +62,11 @@ class ValidationTagLib implements TagLibrary {
     Closure fieldError = { attrs, body ->
         def bean = attrs.bean
         def field = attrs.field
+        def encodeAs = attrs.encodeAs
 
         if (bean && field) {
             if (bean.metaClass.hasProperty(bean, 'errors')) {
-                return messageImpl(error: bean.errors?.getFieldError(field), encodeAs: "HTML")
+                return messageImpl(error: bean.errors?.getFieldError(field), encodeAs: encodeAs ?: "HTML")
             }
         }
 


### PR DESCRIPTION
In my grails projects in noticed, that `encodeAs` was not recognized in the `<g:fieldError />` tag. This is my fix for the issue.

This is my first pull request ever, so please be gentle 😄 