### PR TITLE
Improve Github Workflows

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -32,7 +32,7 @@ version-resolver:
       - 'type: patch'
   default: patch
 template: |
-  ## Changes
+  ## What's Changed
 
   $CHANGES
 

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,12 +1,12 @@
-name-template: $NEXT_PATCH_VERSION
-tag-template: v$NEXT_PATCH_VERSION
+name-template: $RESOLVED_VERSION
+tag-template: v$RESOLVED_VERSION
 categories:
-  - title: 🚀 Features
+  - title: ✨ Features
     labels:
       - "type: enhancement"
       - "type: new feature"
       - "type: major"
-  - title: 🚀 Bug Fixes/Improvements
+  - title: 🐛 Bug Fixes/Improvements
     labels:
       - "type: improvement"
       - "type: bug"
@@ -15,7 +15,22 @@ categories:
     labels:
       - "type: dependency upgrade"
       - "dependencies"
+  - title: ⚙️ Build/CI
+    labels:
+      - "type: ci"
+      - "type: build"
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+version-resolver:
+  major:
+    labels:
+      - 'type: major'
+  minor:
+    labels:
+      - 'type: minor'
+  patch:
+    labels:
+      - 'type: patch'
+  default: patch
 template: |
   ## Changes
 

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -19,40 +19,36 @@ jobs:
       GRADLE_OPTS: -Xmx1500m -Dfile.encoding=UTF-8
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/cache@v2
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
       - name: Set up JDK
         uses: actions/setup-java@v2
         with:
           distribution: 'adopt'
           java-version: ${{ matrix.java }}
-      - name: Optional setup step
-        run: |
-          [ -f ./setup.sh ] && ./setup.sh || true
-      - name: Run Tests
-        run: ./gradlew check
+      - name: Run Build
+        uses: gradle/gradle-build-action@v2
+        env:
+          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+        with:
+          arguments: clean build
       - name: Publish Test Report
         if: failure()
         uses: scacap/action-surefire-report@v1
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           report_paths: '**/build/test-results/test/TEST-*.xml'
-      - name: Run Assemble
-        if: success() && github.event_name == 'push' && matrix.java == '8'
-        run: ./gradlew assemble
       - name: Publish to repo.grails.org
         if: success() && github.event_name == 'push' && matrix.java == '8'
+        uses: gradle/gradle-build-action@v2
         env:
           ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
           ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
-        run: |
-          ./gradlew publish
-          echo "Publishing Docs..."
-          ./gradlew docs
+        with:
+          arguments: publish
+      - name: Build Docs
+        if: success() && github.event_name == 'push' && matrix.java == '8'
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: docs
       - name: Publish to Github Pages
         if: success() && github.event_name == 'push' && matrix.java == '8'
         uses: micronaut-projects/github-pages-deploy-action@master

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -25,32 +25,34 @@ jobs:
           distribution: 'adopt'
           java-version: ${{ matrix.java }}
       - name: Run Build
+        id: build
         uses: gradle/gradle-build-action@v2
         env:
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
         with:
           arguments: clean build
-      - name: Publish Test Report
-        if: failure()
-        uses: scacap/action-surefire-report@v1
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Publish to repo.grails.org
-        if: success() && github.event_name == 'push' && matrix.java == '8'
+        if: steps.build.outcome == 'success' && github.event_name == 'push' && matrix.java == '8'
         uses: gradle/gradle-build-action@v2
         env:
           ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
           ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
         with:
           arguments: publish
+      - name: Publish Test Report
+        if: steps.build.outcome == 'failure'
+        uses: scacap/action-surefire-report@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          report_paths: '**/build/test-results/test/TEST-*.xml'
       - name: Build Docs
-        if: success() && github.event_name == 'push' && matrix.java == '8'
+        id: docs
+        if: steps.build.outcome == 'success' && github.event_name == 'push' && matrix.java == '8'
         uses: gradle/gradle-build-action@v2
         with:
           arguments: docs
       - name: Publish to Github Pages
-        if: success() && github.event_name == 'push' && matrix.java == '8'
+        if: steps.docs.outcome == 'success' && github.event_name == 'push' && matrix.java == '8'
         uses: micronaut-projects/github-pages-deploy-action@master
         env:
           TARGET_REPOSITORY: ${{ github.repository }}


### PR DESCRIPTION
* Use gradle/gradle-build-action@v2 instead of maintaining Gradle cache manually.
* Resolve Release Notes name and tag based on version-resolver. 
* Add a new section of "Build/CI Changes" in Release Notes
* Change the title of Release notes from "Changes" to "What's Changed"
