### PR TITLE
Fixed Grails issue #12460

### DIFF
--- a/grails-gsp/src/main/groovy/org/grails/gsp/GroovyPagesTemplateEngine.java
+++ b/grails-gsp/src/main/groovy/org/grails/gsp/GroovyPagesTemplateEngine.java
@@ -202,14 +202,6 @@ public class GroovyPagesTemplateEngine extends ResourceAwareTemplateEngine imple
     }
 
     /**
-     * Sets the ClassLoader that the TemplateEngine should use to
-     * @param classLoader The ClassLoader to use when compilation of Groovy Pages occurs
-     */
-    public void setClassLoader(ClassLoader classLoader) {
-        this.classLoader = classLoader;
-    }
-
-    /**
      * Retrieves a line number matrix for the specified page that can be used
      * to retrieve the actual line number within the GSP page if the line number within the
      * compiled GSP is known

--- a/grails-plugin-gsp/src/main/groovy/org/grails/plugins/web/GroovyPagesGrailsPlugin.groovy
+++ b/grails-plugin-gsp/src/main/groovy/org/grails/plugins/web/GroovyPagesGrailsPlugin.groovy
@@ -202,7 +202,7 @@ class GroovyPagesGrailsPlugin extends Plugin {
 
         // Setup the main templateEngine used to render GSPs
         groovyPagesTemplateEngine(GroovyPagesTemplateEngine) { bean ->
-            classLoader = ref("classLoader")
+            bean.lazyInit = true
             groovyPageLocator = groovyPageLocator
             if (enableReload) {
                 reloadEnabled = enableReload


### PR DESCRIPTION
Use BeanClassLoaderAware, no need to set classLoader property declaratively.

See https://github.com/grails/grails-core/issues/12460