### PR TITLE
Check onChange event source of GroovyPagesGrailsPlugin

### DIFF
--- a/grails-plugin-gsp/src/main/groovy/org/grails/plugins/web/GroovyPagesGrailsPlugin.groovy
+++ b/grails-plugin-gsp/src/main/groovy/org/grails/plugins/web/GroovyPagesGrailsPlugin.groovy
@@ -299,11 +299,14 @@ class GroovyPagesGrailsPlugin extends Plugin {
 
     @Override
     void onChange(Map<String, Object> event) {
+        if (!(event.source instanceof Class)) {
+            return
+        }
         def application = grailsApplication
         def ctx = applicationContext
 
-        if (application.isArtefactOfType(TagLibArtefactHandler.TYPE, event.source)) {
-            GrailsTagLibClass taglibClass = (GrailsTagLibClass)application.addArtefact(TagLibArtefactHandler.TYPE, event.source)
+        if (application.isArtefactOfType(TagLibArtefactHandler.TYPE, (Class)event.source)) {
+            GrailsTagLibClass taglibClass = (GrailsTagLibClass)application.addArtefact(TagLibArtefactHandler.TYPE, (Class)event.source)
             if (taglibClass) {
                 // replace tag library bean
                 def beanName = taglibClass.fullName


### PR DESCRIPTION
When a controller class changed, this exception will be throw,
``` 
groovy.lang.MissingMethodException: No signature of method: grails.core.DefaultGrailsApplication.isArtefactOfType() is applicable for argument types: (String, org.springframework.core.io.FileSystemResource)
Possible solutions: isArtefactOfType(java.lang.String, java.lang.Class), isArtefactOfType(java.lang.String, java.lang.String)
        at org.codehaus.groovy.runtime.ScriptBytecodeAdapter.unwrap(ScriptBytecodeAdapter.java:70)
        at org.codehaus.groovy.runtime.callsite.PogoMetaClassSite.call(PogoMetaClassSite.java:50)
        at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCall(CallSiteArray.java:47)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:125)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.call(AbstractCallSite.java:148)
        at org.grails.plugins.web.GroovyPagesGrailsPlugin.onChange(GroovyPagesGrailsPlugin.groovy:305)
        at org.grails.plugins.DefaultGrailsPlugin.notifyOfEvent(DefaultGrailsPlugin.java:725)
        at grails.plugins.DefaultGrailsPluginManager.informObservers(DefaultGrailsPluginManager.java:222)
        at org.grails.plugins.DefaultGrailsPlugin.notifyOfEvent(DefaultGrailsPlugin.java:749)
        at org.grails.plugins.AbstractGrailsPluginManager.informOfClassChange(AbstractGrailsPluginManager.java:542)
        at org.grails.plugins.AbstractGrailsPluginManager.informOfFileChange(AbstractGrailsPluginManager.java:485)
        at grails.plugins.GrailsPluginManager$informOfFileChange$1.call(Unknown Source)
```