### PR TITLE
Fix #254 FormTagLib.booleanAttributes fixed

### DIFF
--- a/grails-plugin-gsp/src/main/groovy/org/grails/plugins/web/taglib/FormTagLib.groovy
+++ b/grails-plugin-gsp/src/main/groovy/org/grails/plugins/web/taglib/FormTagLib.groovy
@@ -51,18 +51,20 @@ import org.springframework.web.servlet.support.RequestDataValueProcessor
 @Slf4j
 class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrary, GrailsConfigurationAware {
 
-    private static final DEFAULT_CURRENCY_CODES = ['EUR', 'XCD', 'USD', 'XOF', 'NOK', 'AUD',
-                                                   'XAF', 'NZD', 'MAD', 'DKK', 'GBP', 'CHF',
-                                                   'XPF', 'ILS', 'ROL', 'TRL']
+    private static final List<String> DEFAULT_CURRENCY_CODES = ['EUR', 'XCD', 'USD', 'XOF', 'NOK', 'AUD',
+                                                                'XAF', 'NZD', 'MAD', 'DKK', 'GBP', 'CHF',
+                                                                'XPF', 'ILS', 'ROL', 'TRL']
+
+    private static final List<String> DEFAULT_BOOLEAN_ATTRIBUTES = ['disabled', 'checked', 'readonly', 'required']
 
     ApplicationContext applicationContext
     RequestDataValueProcessor requestDataValueProcessor
     ConversionService conversionService
     GrailsTagDateHelper grailsTagDateHelper
-    
+
     CodecLookup codecLookup
 
-    private List<String> booleanAttributes = ['disabled', 'checked', 'readonly','required']
+    private List<String> booleanAttributes = DEFAULT_BOOLEAN_ATTRIBUTES
 
     void afterPropertiesSet() {
         if (applicationContext.containsBean('requestDataValueProcessor')) {
@@ -345,7 +347,7 @@ class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrar
             if (v != null) {
                 writer << k
                 writer << '="'
-                writer << (htmlEncoder != null ? htmlEncoder.encode(v) : v) 
+                writer << (htmlEncoder != null ? htmlEncoder.encode(v) : v)
                 writer << '" '
             }
         }
@@ -1188,9 +1190,9 @@ class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrar
             // process remaining attributes
             outputAttributes(attrs, radioWriter)
             radioWriter << "/>"
-            
+
             it.radio = raw(radioWriter.buffer)
-            
+
             it.label = labels == null ? 'Radio ' + val : labels[idx]
 
             out << body(it)
@@ -1220,6 +1222,6 @@ class FormTagLib implements ApplicationContextAware, InitializingBean, TagLibrar
     void setConfiguration(Config co) {
         // Some attributes can be treated as boolean, but must be converted to the
         // expected value.
-        booleanAttributes = co.getProperty('grails.tags.booleanToAttributes', List, ['disabled', 'checked', 'readonly'])
+        booleanAttributes = co.getProperty('grails.tags.booleanToAttributes', List, DEFAULT_BOOLEAN_ATTRIBUTES)
     }
 }

--- a/grails-plugin-gsp/src/test/groovy/org/grails/web/taglib/FormTagLibTests.groovy
+++ b/grails-plugin-gsp/src/test/groovy/org/grails/web/taglib/FormTagLibTests.groovy
@@ -231,18 +231,18 @@ class FormTagLibTests extends Specification implements TagLibUnitTest<FormTagLib
     def testTextFieldTagWithNonBooleanAttributesAndNoConfig() {
         when:
         unRegisterRequestDataValueProcessor()
-        def template = '<g:textField name="testField" value="1" disabled="false" checked="false" readonly="false" required="false" />'
+        def template = '<g:textField name="testField" value="1" disabled="false" checked="false" readonly="false" bogus="false" />'
         String output = applyTemplate(template)
 
         then:
-        output == '<input type="text" name="testField" value="1" required="false" id="testField" />'
+        output == '<input type="text" name="testField" value="1" bogus="false" id="testField" />'
 
         when:
-        template = '<g:textField name="testField" value="1" disabled="true" checked="true" readonly="true" required="true"/>'
+        template = '<g:textField name="testField" value="1" disabled="true" checked="true" readonly="true" required="true" bogus="true" />'
         output = applyTemplate(template)
 
         then:
-        output == '<input type="text" name="testField" value="1" required="true" disabled="disabled" checked="checked" readonly="readonly" id="testField" />'
+        output == '<input type="text" name="testField" value="1" bogus="true" disabled="disabled" checked="checked" readonly="readonly" required="required" id="testField" />'
     }
 
 

--- a/grails-plugin-gsp/src/test/groovy/org/grails/web/taglib/FormTagLibWithConfigSpec.groovy
+++ b/grails-plugin-gsp/src/test/groovy/org/grails/web/taglib/FormTagLibWithConfigSpec.groovy
@@ -17,25 +17,24 @@ import spock.lang.Specification
 class FormTagLibWithConfigSpec extends Specification implements TagLibUnitTest<FormTagLib> {
 
     Closure doWithConfig() {{ config ->
-        config.grails.tags.booleanToAttributes = ['disabled','checked','readonly','required']
+        config.grails.tags.booleanToAttributes = ['disabled','checked','readonly','required','bogus']
     }}
 
     def testTextFieldTagWithNonBooleanAttributesAndConfig() {
         when:
 
-        def template = '<g:textField name="testField" value="1" disabled="false" checked="false" readonly="false" required="false" />'
+        def template = '<g:textField name="testField" value="1" disabled="false" checked="false" readonly="false" required="false" bogus="false" />'
         String output = applyTemplate(template)
 
         then:
         assert output == '<input type="text" name="testField" value="1" id="testField" />'
-        //assert output == '<input type="text" name="testField" value="1" required="false" id="testField" />'
 
         when:
-        template = '<g:textField name="testField" value="1" disabled="true" checked="true" readonly="true" required="true"/>'
+        template = '<g:textField name="testField" value="1" disabled="true" checked="true" readonly="true" required="true" bogus="true" />'
         output = applyTemplate(template)
 
         then:
-        assert output == '<input type="text" name="testField" value="1" disabled="disabled" checked="checked" readonly="readonly" required="required" id="testField" />'
+        assert output == '<input type="text" name="testField" value="1" disabled="disabled" checked="checked" readonly="readonly" required="required" bogus="bogus" id="testField" />'
 
     }
 


### PR DESCRIPTION
* `required` now a default (was attempted, but was overwritten in `setConfiguration` with a different set of defaults
* now has a `DEFAULT_BOOLEAN_ATTRIBUTES` list
* Tests adjusted accordingly