### PR TITLE
Resolve ability to render jsp pages if jstl is installed. Fixes #110

### DIFF
--- a/grails-plugin-gsp/src/main/groovy/org/grails/plugins/web/GroovyPagesGrailsPlugin.groovy
+++ b/grails-plugin-gsp/src/main/groovy/org/grails/plugins/web/GroovyPagesGrailsPlugin.groovy
@@ -242,6 +242,7 @@ class GroovyPagesGrailsPlugin extends Plugin {
         abstractViewResolver {
             prefix = GrailsApplicationAttributes.PATH_TO_VIEWS
             suffix = jstlPresent ? GroovyPageViewResolver.JSP_SUFFIX : GroovyPageViewResolver.GSP_SUFFIX
+            resolveJspView = jstlPresent
             templateEngine = groovyPagesTemplateEngine
             groovyPageLocator = groovyPageLocator
             if (enableReload) {


### PR DESCRIPTION
The [Grails Documentation](https://docs.grails.org/6.0.0/guide/single.html#modelsAndViews) states

_"Grails also supports JSPs as views, so if a GSP isn’t found in the expected location but a JSP is, it will be used instead."_

but it appears this was [broken a long time ago](https://github.com/grails/grails-gsp/issues/110).

The [GroovyPageViewResolver](https://github.com/grails/grails-gsp/blob/f67562116c562808828d28d281b775083f8345d5/grails-web-gsp/src/main/groovy/org/grails/web/servlet/view/GroovyPageViewResolver.java#L234-L240) will not render a JSP page unless the `resolveJspView` property is set to true.

This fix works according to the [grails-jsp](https://gsp.grails.org/latest/guide/index.html#usingJSPTagLibraries) documentation, by enabling jsp support if the jstl libraries are detected.  

