### PR TITLE
Decouple Grails from SiteMesh 2 by not forcing GroovyPageLayoutFinder when grails.gsp.view.layoutViewResolver=false

### DIFF
--- a/grails-plugin-gsp/src/main/groovy/org/grails/plugins/web/GroovyPagesGrailsPlugin.groovy
+++ b/grails-plugin-gsp/src/main/groovy/org/grails/plugins/web/GroovyPagesGrailsPlugin.groovy
@@ -113,7 +113,7 @@ class GroovyPagesGrailsPlugin extends Plugin {
         long gspCacheTimeout = config.getProperty(GSP_RELOAD_INTERVAL, Long,  (developmentMode && env == Environment.DEVELOPMENT) ? 0L : 5000L)
         boolean enableCacheResources = !config.getProperty(GroovyPagesTemplateEngine.CONFIG_PROPERTY_DISABLE_CACHING_RESOURCES, Boolean, false)
         String viewsDir = config.getProperty(GSP_VIEWS_DIR, '')
-        def disableLayoutViewResolver = config.getProperty(GSP_VIEW_LAYOUT_RESOLVER_ENABLED, Boolean, true)
+        boolean enableLayoutViewResolver = config.getProperty(GSP_VIEW_LAYOUT_RESOLVER_ENABLED, Boolean, true)
         String defaultDecoratorNameSetting = config.getProperty(SITEMESH_DEFAULT_LAYOUT, '')
         def sitemeshEnableNonGspViews = config.getProperty(SITEMESH_ENABLE_NONGSP, Boolean, false)
 
@@ -257,7 +257,7 @@ class GroovyPagesGrailsPlugin extends Plugin {
         // "grails.gsp.view.layoutViewResolver=false" can be used to disable GrailsLayoutViewResolver
         // containsKey check must be made to check existence of boolean false values in ConfigObject
 
-        if(disableLayoutViewResolver) {
+        if (enableLayoutViewResolver) {
             grailsLayoutViewResolverPostProcessor(GrailsLayoutViewResolverPostProcessor)
         }
 

--- a/grails-plugin-gsp/src/main/groovy/org/grails/plugins/web/GroovyPagesGrailsPlugin.groovy
+++ b/grails-plugin-gsp/src/main/groovy/org/grails/plugins/web/GroovyPagesGrailsPlugin.groovy
@@ -223,14 +223,6 @@ class GroovyPagesGrailsPlugin extends Plugin {
             bean.autowire = true
         }
 
-
-
-        groovyPageLayoutFinder(GroovyPageLayoutFinder) {
-            gspReloadEnabled = enableReload
-            defaultDecoratorName = defaultDecoratorNameSetting ?: null
-            enableNonGspViews = sitemeshEnableNonGspViews
-        }
-
         // Setup the GroovyPagesUriService
         groovyPagesUriService(DefaultGroovyPagesUriService) { bean ->
             bean.lazyInit = true
@@ -258,6 +250,11 @@ class GroovyPagesGrailsPlugin extends Plugin {
         // containsKey check must be made to check existence of boolean false values in ConfigObject
 
         if (enableLayoutViewResolver) {
+            groovyPageLayoutFinder(GroovyPageLayoutFinder) {
+                gspReloadEnabled = enableReload
+                defaultDecoratorName = defaultDecoratorNameSetting ?: null
+                enableNonGspViews = sitemeshEnableNonGspViews
+            }
             grailsLayoutViewResolverPostProcessor(GrailsLayoutViewResolverPostProcessor)
         }
 


### PR DESCRIPTION
Grails supports disabling SiteMesh by using the following setting:
`grails.gsp.view.layoutViewResolver=false`

However, the `GroovyPagesGrailsPlugin` is still forcing `GroovyPageLayoutFinder` even though the only use for it is if `layoutViewResolver=true`.  

This fixes the problem and also opens the possibility to use SiteMesh 3 without having the SiteMesh 2 libraries installed. 

Once this merge is complete, SiteMesh 3 can be enabled using the following plugin:
https://github.com/codeconsole/grails-sitemesh3

This also corrects the improper naming of the `disableLayoutViewResolver` variable. Is has been renamed to `enableLayoutViewResolver` to properly reflect what it represents.  It is not referenced outside this file and the name change is non breaking.