### PR TITLE
Race condition: GroovyPagesTemplateRenderer.afterPropertiesSet() is c…

### DIFF
--- a/grails-plugin-gsp/src/main/groovy/org/grails/plugins/web/GroovyPagesGrailsPlugin.groovy
+++ b/grails-plugin-gsp/src/main/groovy/org/grails/plugins/web/GroovyPagesGrailsPlugin.groovy
@@ -201,7 +201,7 @@ class GroovyPagesGrailsPlugin extends Plugin {
         }
 
         // Setup the main templateEngine used to render GSPs
-        groovyPagesTemplateEngine(GroovyPagesTemplateEngine) { bean ->
+        groovyPagesTemplateEngine(GroovyPagesTemplateEngine) {
             classLoader = ref("classLoader")
             groovyPageLocator = groovyPageLocator
             if (enableReload) {
@@ -221,6 +221,9 @@ class GroovyPagesGrailsPlugin extends Plugin {
 
         groovyPagesTemplateRenderer(GroovyPagesTemplateRenderer) { bean ->
             bean.autowire = true
+            if (enableReload) {
+                reloadEnabled = enableReload
+            }
         }
 
         // Setup the GroovyPagesUriService

--- a/grails-web-gsp/src/main/groovy/org/grails/web/gsp/GroovyPagesTemplateRenderer.java
+++ b/grails-web-gsp/src/main/groovy/org/grails/web/gsp/GroovyPagesTemplateRenderer.java
@@ -86,7 +86,15 @@ public class GroovyPagesTemplateRenderer implements InitializingBean {
             generateViewMethod = ReflectionUtils.findMethod(scaffoldingTemplateGenerator.getClass(), "generateView", new Class<?>[] {
                 GrailsDomainClass.class, String.class, Writer.class});
         }
-        reloadEnabled = groovyPagesTemplateEngine.isReloadEnabled();
+    }
+
+    /**
+     * Sets whether reloading is enabled
+     *
+     * @param reloadEnabled True if it is enabled
+     */
+    public void setReloadEnabled(boolean reloadEnabled) {
+        this.reloadEnabled = reloadEnabled;
     }
 
     public void clearCache() {


### PR DESCRIPTION
…alled before GroovyPagesTemplateEngine is autowired, so reloadEnabled is always false. Fixes #238