### PR TITLE
grails-plugin-sitemesh2 needs to be api because GroovyPageLayoutFinder is needed during :compileGroovy

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 title=Groovy Server Pages (GSP)
 authors=Puneet Behl
-projectVersion=6.0.3-SNAPSHOT
+projectVersion=6.0.4-SNAPSHOT
 projectDesc=GSP (Groovy Server Pages) - A server-side view rendering technology based on Groovy
 projectUrl=https://github.com/grails/grails-gsp
 githubSlug=grails/grails-gsp

--- a/grails-gsp/src/main/groovy/org/grails/gsp/GroovyPagesTemplateEngine.java
+++ b/grails-gsp/src/main/groovy/org/grails/gsp/GroovyPagesTemplateEngine.java
@@ -528,12 +528,8 @@ public class GroovyPagesTemplateEngine extends ResourceAwareTemplateEngine imple
         String path = getPathForResource(res);
         try {
         	String gspSource = IOUtils.toString(inputStream, getGspEncoding());
-            parser = new GroovyPageParser(name, path, path, decorateGroovyPageSource(new StringBuilder(gspSource)).toString());
-
-            if (grailsApplication != null) {
-                Config config = grailsApplication.getConfig();
-                parser.configure(config);
-            }
+            parser = new GroovyPageParser(name, path, path, decorateGroovyPageSource(new StringBuilder(gspSource)).toString(),
+                    grailsApplication != null? grailsApplication.getConfig() : null);
         }
         catch (IOException e) {
             throw new GroovyPagesException("I/O parsing Groovy page ["+(res != null ? res.getDescription() : name)+"]: " + e.getMessage(),e);

--- a/grails-gsp/src/main/groovy/org/grails/gsp/compiler/GroovyPageCompiler.groovy
+++ b/grails-gsp/src/main/groovy/org/grails/gsp/compiler/GroovyPageCompiler.groovy
@@ -206,13 +206,10 @@ class GroovyPageCompiler {
             // gspgroovyfile.getParentFile().mkdirs()
 
             gspfile.withInputStream { InputStream gspinput ->
-                GroovyPageParser gpp = new GroovyPageParser(viewuri - '.gsp', viewuri, gspfile.absolutePath, gspinput, encoding, expressionCodec)
+                GroovyPageParser gpp = new GroovyPageParser(viewuri - '.gsp', viewuri, gspfile.absolutePath, gspinput, encoding, expressionCodec, configMap)
                 gpp.packageName = packageName
                 gpp.className = className
                 gpp.lastModified = gspfile.lastModified()
-                if(configMap) {
-                    gpp.configure(configMap)
-                }
                 StringWriter gsptarget = new StringWriter()
                 gpp.generateGsp(gsptarget)
                 gsptarget.flush()

--- a/grails-plugin-gsp/build.gradle
+++ b/grails-plugin-gsp/build.gradle
@@ -16,7 +16,7 @@ configurations.all {
 dependencies {
     compileOnly "javax.servlet:javax.servlet-api:$servletApiVersion"
     api project(":grails-web-gsp-taglib")
-    implementation project(":grails-plugin-sitemesh2")
+    api project(":grails-plugin-sitemesh2")
 
     runtimeOnly(project(":grails-web-jsp"))
     api "commons-lang:commons-lang:2.6"

--- a/grails-plugin-gsp/src/test/groovy/org/grails/gsp/compiler/tags/GroovyCollectTagTests.java
+++ b/grails-plugin-gsp/src/test/groovy/org/grails/gsp/compiler/tags/GroovyCollectTagTests.java
@@ -25,7 +25,7 @@ public class GroovyCollectTagTests {
     protected void setUp() throws Exception {
         Map context = new HashMap();
         context.put(GroovyPage.OUT, new PrintWriter(sw));
-        GroovyPageParser parser=new GroovyPageParser("test", "test", "test", new ByteArrayInputStream(new byte[]{}));
+        GroovyPageParser parser=new GroovyPageParser("test", "test", "test", new ByteArrayInputStream(new byte[]{}), null);
         context.put(GroovyPageParser.class, parser);
         tag.init(context);
     }

--- a/grails-plugin-gsp/src/test/groovy/org/grails/gsp/compiler/tags/GroovyEachTagTests.groovy
+++ b/grails-plugin-gsp/src/test/groovy/org/grails/gsp/compiler/tags/GroovyEachTagTests.groovy
@@ -18,7 +18,7 @@ class GroovyEachTagTests {
     protected void setUp() throws Exception {
         Map context = new HashMap();
         context.put(GroovyPage.OUT, new PrintWriter(sw));
-        GroovyPageParser parser=new GroovyPageParser("test", "test", "test", new ByteArrayInputStream(new byte[]{}));
+        GroovyPageParser parser=new GroovyPageParser("test", "test", "test", new ByteArrayInputStream(new byte[]{}), null);
         context.put(GroovyPageParser.class, parser);
         tag.init(context);
     }

--- a/grails-plugin-gsp/src/test/groovy/org/grails/gsp/compiler/tags/GroovyFindAllTagTests.groovy
+++ b/grails-plugin-gsp/src/test/groovy/org/grails/gsp/compiler/tags/GroovyFindAllTagTests.groovy
@@ -20,7 +20,7 @@ class GroovyFindAllTagTests {
     protected void setUp() {
         Map context = new HashMap();
         context.put(GroovyPage.OUT, new PrintWriter(sw));
-        GroovyPageParser parser=new GroovyPageParser("test", "test", "test", new ByteArrayInputStream([] as byte[]));
+        GroovyPageParser parser=new GroovyPageParser("test", "test", "test", new ByteArrayInputStream([] as byte[]), null);
         context.put(GroovyPageParser.class, parser);
         tag.init(context);
     }

--- a/grails-plugin-gsp/src/test/groovy/org/grails/gsp/compiler/tags/GroovyGrepTagTests.groovy
+++ b/grails-plugin-gsp/src/test/groovy/org/grails/gsp/compiler/tags/GroovyGrepTagTests.groovy
@@ -18,7 +18,7 @@ class GroovyGrepTagTests {
     protected void setUp() throws Exception {
         Map context = new HashMap();
         context.put(GroovyPage.OUT, new PrintWriter(sw));
-        GroovyPageParser parser=new GroovyPageParser("test", "test", "test", new ByteArrayInputStream(new byte[]{}));
+        GroovyPageParser parser=new GroovyPageParser("test", "test", "test", new ByteArrayInputStream(new byte[]{}), null);
         context.put(GroovyPageParser.class, parser);
         tag.init(context);
     }

--- a/grails-plugin-gsp/src/test/groovy/org/grails/web/pages/ParseTests.java
+++ b/grails-plugin-gsp/src/test/groovy/org/grails/web/pages/ParseTests.java
@@ -196,7 +196,7 @@ public class ParseTests {
         }
 
         InputStream gspIn = new ByteArrayInputStream(gsp.getBytes(enc.toString()));
-        GroovyPageParser parse = new GroovyPageParser(uri, uri, uri, gspIn, enc.toString(), "HTML");
+        GroovyPageParser parse = new GroovyPageParser(uri, uri, uri, gspIn, enc.toString(), "HTML", null);
 
         InputStream in = parse.parse();
         ParsedResult result = new ParsedResult();

--- a/grails-plugin-sitemesh2/build.gradle
+++ b/grails-plugin-sitemesh2/build.gradle
@@ -19,7 +19,7 @@ dependencies {
     astImplementation "org.grails:grails-web:$grailsVersion"
     astImplementation "org.grails:grails-plugin-controllers:$grailsVersion"
 
-    implementation project(":grails-web-sitemesh"), {
+    api project(":grails-web-sitemesh"), {
         exclude group:'org.grails', module:'grails-web-common'
     }
 }

--- a/grails-web-gsp/src/test/groovy/org/grails/web/gsp/io/GrailsConventionGroovyPageLocatorSpec.groovy
+++ b/grails-web-gsp/src/test/groovy/org/grails/web/gsp/io/GrailsConventionGroovyPageLocatorSpec.groovy
@@ -216,7 +216,7 @@ class GrailsConventionGroovyPageLocatorSpec extends Specification {
         def descriptor = new BinaryGrailsPluginDescriptor(resource, ['org.grails.web.gsp.io.TestBinaryResource'])
         resource.relativesResources['static/css/main.css'] = new ByteArrayResource(''.bytes)
         def binaryPlugin = new BinaryGrailsPlugin(TestBinaryGrailsPlugin, descriptor, new DefaultGrailsApplication())
-        GroovyPageParser gpp = new GroovyPageParser("binaryView","/test/binaryView.gsp","/test/binaryView.gsp",new ByteArrayInputStream("hello world".bytes), "UTF-8", "HTML")
+        GroovyPageParser gpp = new GroovyPageParser("binaryView","/test/binaryView.gsp","/test/binaryView.gsp",new ByteArrayInputStream("hello world".bytes), "UTF-8", "HTML", null)
         gpp.packageName = "foo.bar"
         gpp.className = "test_binary_view"
         gpp.lastModified = System.currentTimeMillis()


### PR DESCRIPTION
grails-plugin-sitemesh2 needs to be api because GroovyPageLayoutFinder is needed during :compileGroovy and grails-web-sitemesh transitive dependency was removed from core in 6.0.1-SNAPSHOT

# This will need to be released before Grails 6.0.1 due to this [grails-core commit](https://github.com/grails/grails-core/commit/13d4afdc1e0dd0b47dee048bf5d0fa2326a68a07)

Also added a fix for [#380](https://github.com/grails/grails-gsp/issues/380).  The configuration was being set too late resulting it certain settings now being honored. 