### PR TITLE
fix(build): Add groupId to root project

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,7 @@ repositories {
     maven { url "https://repo.grails.org/grails/core" }
 }
 
+group = "org.grails"
 version project.projectVersion
 
 ext {


### PR DESCRIPTION
Currently, the task findSonatypeStagingRepo is failing to find the exact match even if the repository exists with same description. This is due to missing groupId, resulting to leading colon in the description.

Fixes #436