### PR TITLE
Expose controller namespace

### DIFF
--- a/grails-web-taglib/src/main/groovy/org/grails/web/taglib/WebRequestTemplateVariableBinding.java
+++ b/grails-web-taglib/src/main/groovy/org/grails/web/taglib/WebRequestTemplateVariableBinding.java
@@ -91,6 +91,11 @@ public class WebRequestTemplateVariableBinding extends AbstractTemplateVariableB
                 return webRequest.getActionName();
             }
         });
+        m.put("namespace", new LazyRequestBasedValue() {
+            public Object evaluate(GrailsWebRequest webRequest) {
+                return webRequest.getControllerNamespace();
+            }
+        });
         m.put("controllerName", new LazyRequestBasedValue() {
             public Object evaluate(GrailsWebRequest webRequest) {
                 return webRequest.getControllerName();


### PR DESCRIPTION
Seems logical that [namespace](https://docs.grails.org/6.1.2/ref/Controllers/namespace.html) should be directly accessible from inside a gsp.