### PR TITLE
Allow optional attribute for g.render that will ignore if tag if template does not exist.

### DIFF
--- a/grails-web-gsp-taglib/src/main/groovy/org/grails/plugins/web/taglib/RenderTagLib.groovy
+++ b/grails-web-gsp-taglib/src/main/groovy/org/grails/plugins/web/taglib/RenderTagLib.groovy
@@ -47,6 +47,7 @@ class RenderTagLib implements TagLibrary {
      * &lt;g:render template="atemplate" bean="${user}" /&gt;<br/>
      *
      * @attr template REQUIRED The name of the template to apply
+     * @attr optional if true, this tag will be ignored when the template does not exist.
      * @attr contextPath the context path to use (relative to the application context path). Defaults to "" or path to the plugin for a plugin view or template.
      * @attr bean The bean to apply the template against
      * @attr model The model to apply the template against as a java.util.Map

--- a/grails-web-gsp/src/main/groovy/org/grails/web/gsp/GroovyPagesTemplateRenderer.java
+++ b/grails-web-gsp/src/main/groovy/org/grails/web/gsp/GroovyPagesTemplateRenderer.java
@@ -115,6 +115,10 @@ public class GroovyPagesTemplateRenderer implements InitializingBean {
         final Object controller = webRequest.getAttribute(GrailsApplicationAttributes.CONTROLLER, GrailsWebRequest.SCOPE_REQUEST);
         Template t = findAndCacheTemplate(controller, pageScope, templateName, contextPath, pluginName, uri);
         if (t == null) {
+            String optional = getStringValue(attrs, "optional");
+            if (Boolean.parseBoolean(optional.isBlank()? "false" : optional)) {
+                return; // allow missing templates if optional == "true"
+            }
             throw new GrailsTagException("Template not found for name [" + templateName + "] and path [" + uri + "]");
         }
 

--- a/grails-web-gsp/src/main/groovy/org/grails/web/gsp/GroovyPagesTemplateRenderer.java
+++ b/grails-web-gsp/src/main/groovy/org/grails/web/gsp/GroovyPagesTemplateRenderer.java
@@ -115,8 +115,7 @@ public class GroovyPagesTemplateRenderer implements InitializingBean {
         final Object controller = webRequest.getAttribute(GrailsApplicationAttributes.CONTROLLER, GrailsWebRequest.SCOPE_REQUEST);
         Template t = findAndCacheTemplate(controller, pageScope, templateName, contextPath, pluginName, uri);
         if (t == null) {
-            String optional = getStringValue(attrs, "optional");
-            if (Boolean.parseBoolean(optional.isBlank()? "false" : optional)) {
+            if (getBooleanValue(attrs, "optional")) {
                 return; // allow missing templates if optional == "true"
             }
             throw new GrailsTagException("Template not found for name [" + templateName + "] and path [" + uri + "]");
@@ -291,6 +290,12 @@ public class GroovyPagesTemplateRenderer implements InitializingBean {
         Object val = attrs.get(key);
         if (val == null) return "";
         return String.valueOf(val);
+    }
+
+    private boolean getBooleanValue(Map<String, Object> attrs, String key) {
+        String val = getStringValue(attrs, key);
+        if (val.isBlank()) return false;
+        return Boolean.parseBoolean(val);
     }
 
     public void setGroovyPageLocator(GrailsConventionGroovyPageLocator locator) {


### PR DESCRIPTION
Very useful for scaffolding where you could use the same scaffold gsp across multiple controls and produce different behavior.  Without the `optional` attribute the default behavior persists and an exception is thrown.

```gsp
<g:render template="optionalTemplate" optional="true" />
```

For instance:
`/src/main/templates/show.gsp`
```gsp
            <section class="row">
                <div id="show-${propertyName}" class="col-12 content scaffold-show" role="main">
                    <g:render template="/includes/admin/title"/>
                    <g:render template="/includes/admin/filter">
                        <g:render optional="true" template="/${propertyName}/includes/show/main"/>
                    </g:render>
                    <f:display bean="${propertyName}" class="container" listItemClass="row mb-3" labelClass="form-label col-sm-3 text-sm-end" valueClass="col-sm-9" />
                    <g:render template="/includes/admin/actions" model="\${[domain:${propertyName}]}">
                        <g:render optional="true" template="/${propertyName}/includes/show/menu"/>
                    </g:render>
                </div>
            </section>
```