### PR TITLE
Add asciidoctorjVersion dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -186,6 +186,7 @@ subprojects { subproject ->
             documentation "org.apache.groovy:groovy-ant:$groovyVersion"
             documentation "org.apache.groovy:groovy-dateutil:$groovyVersion"
             documentation "org.apache.groovy:groovy-cli-picocli:$groovyVersion"
+            documentation "org.asciidoctor:asciidoctorj:$asciidoctorjVersion"
         }
     }
 
@@ -358,6 +359,7 @@ dependencies {
         documentation "org.apache.groovy:groovy:${groovyVersion}"
         documentation "org.apache.groovy:groovy-ant:$groovyVersion"
         documentation "org.apache.groovy:groovy-cli-picocli:$groovyVersion"
+        documentation "org.asciidoctor:asciidoctorj:$asciidoctorjVersion"
     }
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,6 +6,8 @@ projectUrl=https://github.com/grails/grails-gsp
 githubSlug=grails/grails-gsp
 githubBranch=7.0.x
 developers=Puneet Behl, Graeme Rocher
+
+asciidoctorjVersion=2.5.13
 grailsGradlePluginVersion=7.0.0-SNAPSHOT
 grailsVersion=7.0.0-SNAPSHOT
 groovyVersion=4.0.23


### PR DESCRIPTION
OptionsBuilder.options() exists in 2.5.x but not in 3.0.x version of asciidoctorj

```
Execution failed for task ':publishGuide'.
> No signature of method: static org.asciidoctor.OptionsBuilder.options() is applicable for argument types: () values: []
  Possible solutions: option(java.lang.String, java.lang.Object), print(java.lang.Object), print(java.io.PrintWriter), notify(), toString(), toString()
```