### PR TITLE
Remove `-plain` suffix from plugin artifacts

### DIFF
--- a/gradle/grails-plugin-config.gradle
+++ b/gradle/grails-plugin-config.gradle
@@ -1,0 +1,7 @@
+tasks.named('bootJar') {
+    enabled = false // Plugins should not create a bootJar
+}
+tasks.named('jar', Jar) {
+    enabled = true // Enable the jar task again, as the bootJar task has been disabled
+    archiveClassifier = '' // Remove '-plain' suffix from jar file name
+}

--- a/grails-plugin-gsp/build.gradle
+++ b/grails-plugin-gsp/build.gradle
@@ -41,11 +41,7 @@ dependencies {
 
     testRuntimeOnly "org.grails:grails-plugin-url-mappings:$grailsVersion"
 }
-// disable main class
-bootJar {
-    mainClass.set('dummy.Application')
-}
-findMainClass.onlyIf { false }
+
 test {
     if (isCiBuild) {
         maxParallelForks = 1
@@ -62,3 +58,5 @@ test {
         System.out.flush()
     }
 }
+
+apply from: rootProject.layout.projectDirectory.file('gradle/grails-plugin-config.gradle')

--- a/grails-plugin-sitemesh2/build.gradle
+++ b/grails-plugin-sitemesh2/build.gradle
@@ -23,8 +23,5 @@ dependencies {
         exclude group:'org.grails', module:'grails-web-common'
     }
 }
-// disable main class
-bootJar {
-    mainClass.set('dummy.Application')
-}
-findMainClass.onlyIf { false }
+
+apply from: rootProject.layout.projectDirectory.file('gradle/grails-plugin-config.gradle')


### PR DESCRIPTION
Also disable the `bootJar` task which should not be enabled for Grails plugins.