### PR TITLE
Remove `bootJar` config

### DIFF
--- a/grails-plugin-gsp/build.gradle
+++ b/grails-plugin-gsp/build.gradle
@@ -41,11 +41,6 @@ dependencies {
 
     testRuntimeOnly "org.grails:grails-plugin-url-mappings:$grailsVersion"
 }
-// disable main class
-bootJar {
-    mainClass.set('dummy.Application')
-}
-findMainClass.onlyIf { false }
 test {
     if (isCiBuild) {
         maxParallelForks = 1

--- a/grails-plugin-sitemesh2/build.gradle
+++ b/grails-plugin-sitemesh2/build.gradle
@@ -23,8 +23,3 @@ dependencies {
         exclude group:'org.grails', module:'grails-web-common'
     }
 }
-// disable main class
-bootJar {
-    mainClass.set('dummy.Application')
-}
-findMainClass.onlyIf { false }


### PR DESCRIPTION
This configuration is no longer necessary as the `bootJar` task is disabled by the `org.grails.grails-plugin` Gradle Plugin.