### PR TITLE
Update Release workflow and Develocity integration

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -22,12 +22,10 @@ jobs:
           java-version: '17'
       - name: "🐘 Setup Gradle"
         uses: gradle/actions/setup-gradle@v4
+        with:
+          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
       - name: "🔨 Run Build"
         id: build
-        env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-          DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
-          DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
         run: ./gradlew build --refresh-dependencies
       - name: "📤 Upload Artifact"
         if: success()
@@ -51,11 +49,10 @@ jobs:
           java-version: '17'
       - name: "🐘 Setup Gradle"
         uses: gradle/actions/setup-gradle@v4
+        with:
+          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
       - name: "📤 Publish Snapshot to repo.grails.org"
         env:
-          DEVELOCITY_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-          DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
-          DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
           ARTIFACTORY_USERNAME: ${{ secrets.ARTIFACTORY_USERNAME }}
           ARTIFACTORY_PASSWORD: ${{ secrets.ARTIFACTORY_PASSWORD }}
         run: ./gradlew publish
@@ -75,12 +72,10 @@ jobs:
           java-version: '17'
       - name: "🐘 Setup Gradle"
         uses: gradle/actions/setup-gradle@v4
+        with:
+          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
       - name: "🔨 Build Docs"
         id: docs
-        env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-          DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
-          DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
         run: ./gradlew docs --refresh-dependencies
       - name: "📤 Publish docs to Github Pages"
         if: steps.docs.outcome == 'success'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: "Release"
 on:
   release:
     types: [published]
@@ -13,119 +13,104 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.GH_TOKEN }}
-      - name: Set up JDK
+      - name: "☕️ Setup JDK"
         uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
+          distribution: 'liberica'
           java-version: '17'
-      - name: Set the current release version
+      - name: "📝 Store the current release version"
         id: release_version
         run: echo "value=${GITHUB_REF:11}" >> $GITHUB_OUTPUT
-      - name: Run pre-release
+      - name: "🐘 Setup Gradle"
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+      - name: "⚙ Run pre-release"
         uses: micronaut-projects/github-actions/pre-release@master
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Run Assemble
+      - name: "🧩 Run Assemble"
         if: success()
-        id: assemble
-        uses: gradle/gradle-build-action@v3
-        with:
-          arguments: assemble
-        env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-          DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
-          DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
-      - name: Upload Distribution
+        run: ./gradlew assemble
+      - name: "📤 Upload Distribution"
         if: success()
         uses: actions/upload-artifact@v4
         with:
           name: grails-gsp-${{ steps.release_version.outputs.value }}.zip
           path: ./**/build/libs/*
-      - name: Generate secring file
+      - name: "🔐 Generate key file for artifact signing"
         env:
           SECRING_FILE: ${{ secrets.SECRING_FILE }}
         run: echo $SECRING_FILE | base64 -d > ${{ github.workspace }}/secring.gpg
-      - name: Publish to Sonatype OSSRH
+      - name: "📤 Publish to and close Sonatype staging repository"
         id: publish
-        uses: gradle/gradle-build-action@v3
         env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-          DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
-          DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SONATYPE_STAGING_PROFILE_ID: ${{ secrets.SONATYPE_STAGING_PROFILE_ID }}
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
           SIGNING_PASSPHRASE: ${{ secrets.SIGNING_PASSPHRASE }}
           SECRING_FILE: ${{ secrets.SECRING_FILE }}
-        with:
-          arguments: |
-            -Psigning.secretKeyRingFile=${{ github.workspace }}/secring.gpg 
-            publishToSonatype 
-            closeSonatypeStagingRepository
+        run: >
+          ./gradlew
+          -Psigning.secretKeyRingFile=${{ github.workspace }}/secring.gpg 
+          publishToSonatype 
+          closeSonatypeStagingRepository
   release:
     needs: publish
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
-      - name: Checkout repository
+      - name: "📥 Checkout repository"
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GH_TOKEN }}
           ref: v${{ needs.publish.outputs.release_version }}
-      - name: Nexus Staging Close And Release
-        uses: gradle/gradle-build-action@v3
+      - name: "☕️ Setup JDK"
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'liberica'
+          java-version: '17'
+      - name: "🐘 Setup Gradle"
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+      - name: "🚀 Release Sonatype Staging Repository"
         env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-          DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
-          DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
           SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SONATYPE_STAGING_PROFILE_ID: ${{ secrets.SONATYPE_STAGING_PROFILE_ID }}
-        with:
-          arguments: |
-            findSonatypeStagingRepository
-            releaseSonatypeStagingRepository
-      - name: Run post-release
+        run: >
+          ./gradlew
+          findSonatypeStagingRepository
+          releaseSonatypeStagingRepository
+      - name: "⚙️ Run post-release"
         if: success()
         uses: micronaut-projects/github-actions/post-release@master
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-        env:
-          SNAPSHOT_SUFFIX: -SNAPSHOT
   docs:
     needs: publish
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
-      - name: Checkout repository
+      - name: "📥 Checkout repository"
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GH_TOKEN }}
           ref: v${{ needs.publish.outputs.release_version }}
-      - name: Set up JDK
+      - name: "☕️ Setup JDK"
         uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
+          distribution: 'liberica'
           java-version: '17'
-      - name: Publish Documentation
-        id: docs
-        uses: gradle/gradle-build-action@v3
+      - name: "🐘 Setup Gradle"
+        uses: gradle/actions/setup-gradle@v4
         with:
-          arguments: docs
-        env:
-          DEVELOCITY_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
-          DEVELOCITY_BUILD_CACHE_NODE_USER: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_USER }}
-          DEVELOCITY_BUILD_CACHE_NODE_KEY: ${{ secrets.GRADLE_ENTERPRISE_BUILD_CACHE_NODE_KEY }}
-      - name: Publish to Github Pages
+          develocity-access-key: ${{ secrets.DEVELOCITY_ACCESS_KEY }}
+      - name: "📖 Generate documentation"
+        run: ./gradlew docs
+      - name: "📤 Publish documentation to Github Pages"
         if: success()
         uses: micronaut-projects/github-pages-deploy-action@grails
         env:
-          BETA: ${{ contains(needs.publish.outputs.release_version, 'M') }}
+          BETA: ${{ contains(needs.publish.outputs.release_version, 'M') || contains(needs.publish.outputs.release_version, 'RC') }}
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           BRANCH: gh-pages
           FOLDER: build/docs

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,6 +10,8 @@ def isAuthenticated = System.getenv('DEVELOCITY_ACCESS_KEY') != null
 develocity {
     server = 'https://ge.grails.org'
     buildScan {
+        tag('grails')
+        tag('grails-gsp')
         publishing.onlyIf { isAuthenticated }
         uploadInBackground = isLocal
     }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,14 +1,11 @@
 plugins {
-    id 'com.gradle.develocity' version '3.18.2'
+    id 'com.gradle.develocity' version '3.19'
     id 'com.gradle.common-custom-user-data-gradle-plugin' version '2.0.2'
 }
 
 def isCI = System.getenv('CI') != null
 def isLocal = !isCI
 def isAuthenticated = System.getenv('DEVELOCITY_ACCESS_KEY') != null
-def isBuildCacheAuthenticated =
-        System.getenv('DEVELOCITY_BUILD_CACHE_NODE_USER') != null &&
-        System.getenv('DEVELOCITY_BUILD_CACHE_NODE_KEY') != null
 
 develocity {
     server = 'https://ge.grails.org'
@@ -21,17 +18,12 @@ develocity {
 buildCache {
     local { enabled = isLocal }
     remote(develocity.buildCache) {
-        push = isCI && isBuildCacheAuthenticated
+        push = isCI && isAuthenticated
         enabled = true
-        usernameAndPassword(
-                System.getenv('DEVELOCITY_BUILD_CACHE_NODE_USER') ?: '',
-                System.getenv('DEVELOCITY_BUILD_CACHE_NODE_KEY') ?: ''
-        )
     }
 }
 
-
-rootProject.name = "grails-gsp"
+rootProject.name = 'grails-gsp'
 
 include 'grails-gsp'
 include 'grails-plugin-gsp'


### PR DESCRIPTION
- Switch to using the `DEVELOCITY_ACCESS_KEY` secret for authentication.
- Remove deprecated username and password authentication for the remote build cache.
- Upgrade Develocity plugin to version `3.19`.
- Add tags to build scans.

Also update release CI with:
- Update step names with emojis
- Switch to `liberica` JDK
- Update `setup-gradle` to `v4`
- Update `develocity` authentication
- Remove `GITHUB_TOKEN` assignments where it is already the default
- Add additional check for RC for snapshot documentation publishing