### PR TITLE
Set `org.grails` Maven group for Sitemesh3 plugin

### DIFF
--- a/gradle/publish-config.gradle
+++ b/gradle/publish-config.gradle
@@ -1,7 +1,6 @@
 apply plugin: 'maven-publish'
 apply plugin: 'signing'
 
-ext.set('isGrailsPlugin', project.group == 'org.grails.plugins')
 ext.set('signing.keyId', project.findProperty('signing.keyId') ?: System.getenv('SIGNING_KEY'))
 ext.set('signing.password', project.findProperty('signing.password') ?: System.getenv('SIGNING_PASSPHRASE'))
 ext.set('signing.secretKeyRingFile', project.findProperty('signing.secretKeyRingFile') ?: "${System.properties['user.home']}${File.separator}.gnupg${File.separator}secring.gpg")
@@ -14,7 +13,7 @@ publishing {
                     username = System.getenv('ARTIFACTORY_USERNAME') ?: project.findProperty('artifactoryPublishUsername') ?: ''
                     password = System.getenv('ARTIFACTORY_PASSWORD') ?: project.findProperty('artifactoryPublishPassword') ?: ''
                 }
-                url = isGrailsPlugin ?
+                url = project.findProperty('isGrailsPlugin') ?
                         'https://repo.grails.org/grails/plugins3-snapshots-local' :
                         'https://repo.grails.org/grails/libs-snapshots-local'
             }

--- a/grails-plugin-gsp/build.gradle
+++ b/grails-plugin-gsp/build.gradle
@@ -17,6 +17,7 @@ apply plugin: 'org.grails.grails-plugin'
 
 ext {
     artifactId = 'gsp'
+    isGrailsPlugin = true
     testMaxParallelFork = isCiBuild ? 1 : 4
     testForkEvery = isCiBuild ? 10 : 20
     testJvmArgs = ['-Xmx1536M']

--- a/grails-plugin-sitemesh3/build.gradle
+++ b/grails-plugin-sitemesh3/build.gradle
@@ -9,13 +9,14 @@ buildscript {
 }
 
 version = projectVersion
-group = 'org.grails.plugins'
+group = 'org.grails'
 
 apply plugin: 'groovy'
 apply plugin: 'java-library'
 apply plugin: 'org.grails.grails-plugin'
 
 ext {
+    isGrailsPlugin = true
     pomTitle = 'SiteMesh 3 Grails Plugin'
     pomDescription = 'SiteMesh is a web-page layout and decoration framework and web- application integration framework to aid in creating sites consisting of many pages for which a consistent look/feel, navigation and layout scheme is required.'
     pomDevelopers = [


### PR DESCRIPTION
- After discussion it was decided that `org.grails:grails-plugin-sitemesh3` is the most appropriate Maven coords for this artifact.
- This commit also adapts the condition on which snapshot repository is chosen for plugins vs libraries.